### PR TITLE
Improve navigation clarity and reduce forecast UI friction

### DIFF
--- a/src/components/forecast/ForecastControlsSidebar.tsx
+++ b/src/components/forecast/ForecastControlsSidebar.tsx
@@ -59,16 +59,16 @@ export function ForecastControlsSidebar() {
         <div className="pt-4 space-y-3">
           <label className="space-y-1.5 text-sm font-medium">
             <span className="text-muted-foreground text-xs">Forecast Starts</span>
-            <div className="flex items-center rounded-lg border bg-background/50 px-3 py-2.5">
-              <span>{forecastStartDate}</span>
+            <div className="flex items-center rounded-lg border bg-muted/30 px-3 py-2.5">
+              <span className="text-muted-foreground">{forecastStartDate}</span>
               <CalendarIcon className="ml-auto h-4 w-4 text-muted-foreground" />
             </div>
           </label>
 
           <label className="space-y-1.5 text-sm font-medium">
             <span className="text-muted-foreground text-xs">Forecast Ends</span>
-            <div className="flex items-center rounded-lg border bg-background/50 px-3 py-2.5">
-              <span>{forecastEndDate}</span>
+            <div className="flex items-center rounded-lg border bg-muted/30 px-3 py-2.5">
+              <span className="text-muted-foreground">{forecastEndDate}</span>
               <CalendarIcon className="ml-auto h-4 w-4 text-muted-foreground" />
             </div>
           </label>
@@ -167,8 +167,8 @@ export function ForecastControlsSidebar() {
               value={warningOperator}
               onChange={(e) => setWarningOperator(e.target.value as '<' | '<=')}
             >
-              <option value="<">Balance below thr...</option>
-              <option value="<=">Balance at/below thr...</option>
+              <option value="<">Balance below threshold</option>
+              <option value="<=">Balance at or below threshold</option>
             </select>
           </label>
           <label className="space-y-1.5 text-sm font-medium flex justify-between items-center">
@@ -186,6 +186,9 @@ export function ForecastControlsSidebar() {
               <option value="Balance Color">Balance Color</option>
             </select>
           </label>
+          <p className="text-xs text-muted-foreground">
+            These settings control when the forecast starts warning you and how the warning appears.
+          </p>
         </div>
 
       </div>

--- a/src/components/layout/NavRail.tsx
+++ b/src/components/layout/NavRail.tsx
@@ -26,17 +26,21 @@ export function NavRail() {
   ];
 
   return (
-    <div className="flex h-screen w-16 flex-col items-center justify-between border-r border-border/40 bg-card/40 py-4 z-50">
+    <div className="flex h-screen w-56 flex-col justify-between border-r border-border/40 bg-card/40 py-4 z-50">
       <div className="flex flex-col items-center gap-6">
-        {/* App Logo / Branding */}
-        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-500/10 text-emerald-500 mb-2">
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline>
-          </svg>
+        <div className="flex w-full items-center gap-3 px-4">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-500/10 text-emerald-500">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline>
+            </svg>
+          </div>
+          <div className="min-w-0">
+            <div className="text-sm font-semibold text-foreground">FinCal</div>
+            <div className="text-xs text-muted-foreground">Forecast workspace</div>
+          </div>
         </div>
 
-        {/* Top Nav Links */}
-        <nav className="flex flex-col items-center gap-3">
+        <nav className="flex w-full flex-col gap-1 px-3">
           {navItems.map((item) => {
             const isActive = location.pathname.startsWith(item.path);
             const Icon = item.icon;
@@ -45,28 +49,30 @@ export function NavRail() {
                 key={item.path}
                 to={item.path}
                 title={item.label}
-                className={`flex h-10 w-10 cursor-pointer items-center justify-center rounded-xl transition-colors ${
+                aria-current={isActive ? 'page' : undefined}
+                className={`flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm transition-colors ${
                   isActive
                     ? 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400'
                     : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground'
                 }`}
               >
                 <Icon className="h-5 w-5" />
+                <span className="font-medium">{item.label}</span>
               </Link>
             );
           })}
         </nav>
       </div>
 
-      <div className="flex flex-col items-center gap-3">
-        {/* Bottom actions */}
+      <div className="flex flex-col gap-3 px-3">
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <button
               title="Settings"
-              className="flex h-10 w-10 cursor-pointer items-center justify-center rounded-xl text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground bg-transparent border-none appearance-none"
+              className="flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-sm text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground bg-transparent border-none appearance-none"
             >
               <Settings className="h-5 w-5" />
+              <span className="font-medium">Settings</span>
             </button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start" side="right" sideOffset={12}>
@@ -85,9 +91,10 @@ export function NavRail() {
             <DropdownMenuTrigger asChild>
               <button
                 title={userProfile.name}
-                className="flex h-10 w-10 cursor-pointer items-center justify-center rounded-xl transition-colors hover:bg-muted/50 hover:text-foreground mt-2 bg-transparent border-none appearance-none"
+                className="flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-sm transition-colors hover:bg-muted/50 hover:text-foreground bg-transparent border-none appearance-none"
               >
                 <img src={userProfile.picture} alt={userProfile.name} className="h-7 w-7 rounded-full" />
+                <span className="min-w-0 truncate font-medium text-foreground">{userProfile.name}</span>
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start" side="right" sideOffset={12}>

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -16,9 +16,6 @@ export function LandingPage({ signIn }: LandingPageProps) {
             <Button asChild variant="ghost">
               <Link to="/app">Open App</Link>
             </Button>
-            <Button onClick={signIn} variant="outline">
-              Connect Google
-            </Button>
           </nav>
         </div>
       </header>
@@ -44,6 +41,9 @@ export function LandingPage({ signIn }: LandingPageProps) {
                   Connect Google for Export
                 </Button>
               </div>
+              <p className="text-xs text-white/75">
+                You can use FinCal without Google. Connect it only if you want calendar export.
+              </p>
             </div>
           </div>
         </section>


### PR DESCRIPTION
This PR focuses on UX cleanup from the heuristic review:

- Adds text labels and a branded header to the app nav rail for better orientation
- Makes read-only forecast dates look read-only
- Expands truncated warning-condition labels and adds helper copy
- Removes duplicate Google CTA from the landing header and clarifies that Google is optional

Validation:
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the main navigation with clearer branding, visible section labels, and improved active-state indicators.
  * Added more explanatory text on the landing page to clarify that the app can be used without Google, with Google only needed for calendar export.
  * Added helpful guidance in forecast settings to explain warning timing and display behavior.

* **Style**
  * Refreshed the forecast sidebar and navigation styling for a cleaner, more consistent look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->